### PR TITLE
Allow additional resources to be created

### DIFF
--- a/apb-test.sh
+++ b/apb-test.sh
@@ -230,6 +230,16 @@ function create_sa() {
     printf "\n"
 }
 
+function create_resources() {
+    if [ -n "$resources" ]; then
+        if [ -n "$resources_namespace" ]; then
+            $CMD create -f $resources -n $resources_namespace
+        else
+            $CMD create -f $resources
+        fi
+    fi
+}
+
 # Run the test
 function test_apb() {
     requirements
@@ -239,6 +249,7 @@ function test_apb() {
     setup_cluster
     create_apb_namespace
     create_sa
+    create_resources
     run_apb "test"
 }
 


### PR DESCRIPTION
By providing `resources` and `resources_namespace` env variables it would be possible to provision additional resources if needed.

I needed it because I had to add the imageStreams required for my apb.
```
+create_resources
+'[' -n https://github.com/jboss-container-images/rhpam-7-openshift-image/raw/rhpam70-dev/rhpam70-image-streams.yaml ']'
+'[' -n openshift ']'
+oc create -f https://github.com/jboss-container-images/rhpam-7-openshift-image/raw/rhpam70-dev/rhpam70-image-streams.yaml -n openshift
imagestream "rhpam70-businesscentral-openshift" created
imagestream "rhpam70-businesscentral-monitoring-openshift" created
imagestream "rhpam70-controller-openshift" created
imagestream "rhpam70-kieserver-openshift" created
imagestream "rhpam70-smartrouter-openshift" created
imagestream "rhpam70-businesscentral-indexing-openshift" created
```